### PR TITLE
Handle large values of x

### DIFF
--- a/autograd_gamma/__init__.py
+++ b/autograd_gamma/__init__.py
@@ -1,6 +1,6 @@
 from autograd.extend import primitive, defvjp
 from autograd import numpy as np
-from autograd.scipy.special import gamma
+from autograd.scipy.special import gammaln
 from autograd.numpy.numpy_vjps import unbroadcast_f
 from scipy.special import gammainc as _scipy_gammainc, gammaincc as _scipy_gammaincc
 
@@ -33,7 +33,7 @@ defvjp(
         )
         / (12 * DELTA),
     ),
-    lambda ans, a, x: unbroadcast_f(x, lambda g: g * np.exp(-x) * np.power(x, a - 1) / gamma(a)),
+    lambda ans, a, x: unbroadcast_f(x, lambda g: g * np.exp(-x + np.log(x)*(a - 1) - gammaln(a)))
 )
 
 
@@ -50,7 +50,7 @@ defvjp(
         )
         / (12 * DELTA),
     ),
-    lambda ans, a, x: unbroadcast_f(x, lambda g: -g * np.exp(-x) * np.power(x, a - 1) / gamma(a)),
+    lambda ans, a, x: unbroadcast_f(x, lambda g: -g * np.exp(-x + np.log(x)*(a - 1) - gammaln(a)))
 )
 
 

--- a/tests/test_autograd_gamma.py
+++ b/tests/test_autograd_gamma.py
@@ -42,3 +42,6 @@ def test_a_special_case_of_the_derivative():
     npt.assert_allclose(analytical_derivative(x), approx_derivative(x))
 
 
+def test_large_x():
+    npt.assert_allclose(grad(gammainc, argnum=1)(100., 10000.), 0)
+    npt.assert_allclose(grad(gammaincc, argnum=1)(100., 10000.), 0)


### PR DESCRIPTION
I tried using this with convoys, but the optimization would crash because of `nan` values. The problem is computing the derivative wrt x, where there's a fraction where both the numerator and denominator are `inf` so that the fraction is computed as `nan`.

Doing the computation in the log-domain instead resolves the issue.